### PR TITLE
:bug: added dotenv files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ yarn.lock
 
 # misc
 .DS_Store
+.env
+.env.test
 .env.local
 .env.development.local
 .env.test.local
@@ -68,10 +70,6 @@ typings/
 
 # Yarn Integrity file
 .yarn-integrity
-
-# dotenv environment variables file
-.env
-.env.test
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local


### PR DESCRIPTION
Fixed up some dotenv files (ie .env) in .gitignore

This is in anticipation of some security issues and credential resets.