### PR TITLE
Dotenv configuration for backend

### DIFF
--- a/config/keys.js
+++ b/config/keys.js
@@ -1,3 +1,0 @@
-module.exports = {
-	mongoURI: 'mongodb+srv://gecko:YmXpOYfOQJVnCt4a@cluster0-8mtga.mongodb.net/test?retryWrites=true'
-}

--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ app.use(express.static(path.join(__dirname, 'client/build')));
 // Bodyparser Middleware
 app.use(bodyParser.json());
 
-// DB Config
-const db = require('./config/keys').mongoURI;
+// DB Config from .env file
+require('dotenv').config()
+const db = process.env.MONGO_URI
 
 //Connect to Mongo
 mongoose.connect(db)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "start": "concurrently  \"node index.js\" \"cd client && npm start\"",
     "heroku-postbuild": "cd client && npm install && npm run build",
-    "server": "nodemon index.js"
+    "server": "nodemon index.js",
+    "postinstall": "cd client && npm install"
   },
   "author": "patrick connolly",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "body-parser": "^1.18.3",
     "concurrently": "^4.1.0",
+    "dotenv": "^7.0.0",
     "express": "^4.16.4",
     "mongoose": "^5.4.19"
   },


### PR DESCRIPTION
Added dotenv module to backend and remove keys.js file from the repo.

Express now loads DB key from .env file instead. 

Listed config info in our private docs. 

--------------------

This PR also includes:
Minor touchup to package.json - simply tells it everytime you npm install the main project, also npm install the client.