### PR TITLE
specified node version in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
 language: node_js
-
+node_js:
+  - "10"
 script: npm test


### PR DESCRIPTION
Specifying node version in `travis.yml` will resolve travis build errors in #43.

I chose version 10 because there was some mention of some failing errors in version 11.

 