### PR TITLE
Map habit checkins to calendar values

### DIFF
--- a/client/src/components/CalHM.js
+++ b/client/src/components/CalHM.js
@@ -2,27 +2,41 @@ import React, { Component } from 'react';
 import CalendarHeatmap from 'react-calendar-heatmap';
 import 'react-calendar-heatmap/dist/styles.css';
 import ReactTooltip from 'react-tooltip';
+import moment from 'moment';
 
-class CalHM extends Component {
-
-    render() {
-        return (
-            <div>
-                <CalendarHeatmap
-                    startDate={new Date('2019-01-01')}
-                    endDate={new Date('2019-05-01')}
-                    values={[
-                        { date: '2019-04-20' },
-                        { date: '2019-04-21' },
-                        { date: '2016-04-22' },
-                        { date: '2016-04-23' },
-                        // ...and so on
-                    ]}
-                />
-                <ReactTooltip />
-            </div>
-        )
-
-    }
+const effortLookup = {
+    "skip": 0,
+    "failed": 1,
+    "tried": 2,
+    "completed": 3,
+    "killed-it": 4
 }
+
+// FYI - db date format is 'May 2nd 2019'
+
+const CalHM = ({date, checkins, length}) => {
+    // Hack to not have terrible scaling - at least 3 months
+    const calendarLength = length >= 3 ? length : 3;
+    return (
+        <div>
+            <CalendarHeatmap
+                startDate={date}
+                endDate={moment(date).add(30 * calendarLength, 'days').toDate()}
+
+                values={checkins.map(checkin => ({
+                    date: moment(checkin.checkinDate, 'MMMM DD YYYY').toDate(),
+                    count: effortLookup[checkin.effort]
+                }))}
+                classForValue={(value) => {
+                    if (!value) {
+                        return 'color-empty';
+                    }
+                    return `color-github-${value.count}`;
+                    }}
+            />
+            <ReactTooltip />
+        </div>
+    )
+}
+
 export default CalHM;

--- a/client/src/components/Dashboard.js
+++ b/client/src/components/Dashboard.js
@@ -9,8 +9,8 @@ import HeaderLoggedIn from '../containers/HeaderLoggedIn';
 import NewHabit from './NewHabit';
 import CheckIn from './check-in';
 import CurrentHabit from './CurrentHabit';
-import Progress from './Progress';
 import moment from 'moment';
+import CalHM from '../components/CalHM';
 
 class Dashboard extends Component {
     static propTypes = {
@@ -36,7 +36,7 @@ class Dashboard extends Component {
         providerData: this.props.providerData,
         newEntry: false,
         newEntryButton: true,
-        habitData: [],
+        habitData: {checkins: []},
         user: '',
         hamburgerOpen: false,
         checkIn: false,
@@ -199,7 +199,7 @@ class Dashboard extends Component {
                 <h2>Daily Dashboard</h2>
                 {newHabitButton}
                 {checkInButton}
-                <Progress />
+                <CalHM {...this.state.habitData} />
                 <CurrentHabit {...this.state.habitData} />
             </Layout>
             </div>


### PR DESCRIPTION
Added the logic to map checkin data to populate the calendar values.

Using the github scale for now - looking at @SaraSweetie for custom colors :)

Also added a slight hack to make the calendar at least 3 months if the user's habit is less than 3 months.   Any less than that and the calendar scales wayyyyy too big.

Here's how it maps from effort to "counts":
![image](https://user-images.githubusercontent.com/2468330/57117527-a5400100-6d2a-11e9-8614-327aba595985.png)
