### PR TITLE
Css mobile

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -467,6 +467,15 @@ fieldset {
     width: 35px;
     height: 35px;
   }
+  #sidebar {
+      max-width: 40%;
+      width: calc(100% - 30px);
+      padding: 30px;
+      margin-left: 30px;
+      position: absolute;
+        top: 123px; /*height of header */
+        left: 0;
+  }
   main {
     margin: 15px;
   }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -481,7 +481,10 @@ fieldset {
   }
   .circle {
     border-radius: 0;
-    padding-bottom: 20%;
     border-radius: 20px;
+    width: 70%;
+    height: auto;
+    margin: 3% 10%;
+    padding: 5%;
   }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -479,4 +479,9 @@ fieldset {
   main {
     margin: 15px;
   }
+  .circle {
+    border-radius: 0;
+    padding-bottom: 20%;
+    border-radius: 20px;
+  }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -450,10 +450,24 @@ fieldset {
 @media screen and (max-width:500px) {
   .headerLogin {
     position: relative;
+    align-items: flex-start;
+    width: 94%;
+    max-height: 150px;
+    padding: 5px 3% 10px 3%;
+  }
+  .headerLogin h1 {
+    font-size: 1.5em;
   }
   #hamburger-menu {
     position: absolute;
       left: 10px;
       bottom: 10px;
+  }
+  .container__profile--photo {
+    width: 35px;
+    height: 35px;
+  }
+  main {
+    margin: 15px;
   }
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -444,3 +444,16 @@ fieldset {
   box-shadow: 1px 3px #888888;
   font-weight: 600;
 }
+
+/* ---------- Header adjustments for small screen ---------- */
+
+@media screen and (max-width:500px) {
+  .headerLogin {
+    position: relative;
+  }
+  #hamburger-menu {
+    position: absolute;
+      left: 10px;
+      bottom: 10px;
+  }
+}


### PR DESCRIPTION
- Header contents adjusted for mobile view
- hamburger slide out menu adjusted because header height was changed from above
- log in circle removed for width less than 500px

<img width="498" alt="Screen Shot 2019-05-04 at 1 05 55 PM" src="https://user-images.githubusercontent.com/33433415/57182480-7c745480-6e6d-11e9-9881-0e75c1b65e8d.png">

<img width="492" alt="Screen Shot 2019-05-04 at 1 06 19 PM" src="https://user-images.githubusercontent.com/33433415/57182508-c52c0d80-6e6d-11e9-9c00-120f0d946e8e.png">

<img width="480" alt="Screen Shot 2019-05-04 at 1 06 28 PM" src="https://user-images.githubusercontent.com/33433415/57182482-81d19f00-6e6d-11e9-9a98-28ad9f5b18c5.png">

