### PR TITLE
🎨  - changed colors for skipped; remove null text

### DIFF
--- a/client/src/components/CalHM.js
+++ b/client/src/components/CalHM.js
@@ -32,12 +32,12 @@ const CalHM = ({date, checkins, length, selectCheckin}) => {
                     if (!value) {
                         return 'color-empty';
                     }
-                    return `color-github-${value.count}`;
+                    return `color-checkin-${value.count}`;
                 }}
 
                 tooltipDataAttrs={value => {
                     const dataTip = value.effort ? `On ${value.dateFriendly} you ${value.effort}` :
-                                                   `You skipped this day`;
+                                                   ``;
                     return {
                        'data-tip': dataTip,
                     };

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -405,8 +405,20 @@ fieldset {
 }
 
 /* Heat Map calendar */
-.react-calendar-heatmap text {
-  font-size: 7px;
+.react-calendar-heatmap .color-checkin-0 {
+  fill: #ededed;
+}
+.react-calendar-heatmap .color-checkin-1 {
+  fill: #808080;
+}
+.react-calendar-heatmap .color-checkin-2 {
+  fill: #7fa8d1;
+}
+.react-calendar-heatmap .color-checkin-3 {
+  fill: #49729b;
+}
+.react-calendar-heatmap .color-checkin-4 {
+  fill: #254e77;
 }
 
 /* ------------------------------- copied from SocialProfileList.css   -------------------------------*/


### PR DESCRIPTION
After talking with the team having a different color between 'skip' and 'fail' was important; also remove the text for null value on the tooltip prevents the tooltip showing up on future dates without data.